### PR TITLE
gpu power capping config CRD

### DIFF
--- a/deploy/climatik-operator/manifests/crd.yaml
+++ b/deploy/climatik-operator/manifests/crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: powercappingconfigs.powercapping.climatik-project.ai
+  name: gpupowercappingconfigs.powercapping.climatik-project.ai
 spec:
   group: powercapping.climatik-project.ai
   versions:
@@ -15,46 +15,20 @@ spec:
             spec:
               type: object
               properties:
-                powerCapLimit:
+                workloadType:
+                  type: string
+                  enum: ["training", "inference"]
+                efficiencyLevel:
+                  type: string
+                  enum: ["high", "medium", "low"]
+                powerCapWatts:
                   type: integer
-                  minimum: 0
-                scaledObjectRefs:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      metadata:
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                          - name
-                          - namespace
-                    required:
-                      - apiVersion
-                      - kind
-                      - metadata
-              required:
-                - powerCapLimit
-                - scaledObjectRefs
-            status:
-              type: object
-              properties:
-                currentPowerConsumption:
-                  type: number
-                forecastPowerConsumption:
-                  type: number
+                temperatureThresholdCelsius:
+                  type: integer
   scope: Namespaced
   names:
-    plural: powercappingconfigs
-    singular: powercappingconfig
+    plural: gpupowercappingconfigs
+    singular: gpupowercappingconfig
     kind: PowerCappingConfig
     shortNames:
-      - pcc
+      - gpcc


### PR DESCRIPTION
This PR focuses on GPU Power Capping use case. The CRD provides additional configuration to specify GPU workload: training, inference,  power capping threshold, efficiency levels, and temperature. Operator will use the setting for scaling and tuning decisions.