### PR TITLE
fix: Add powerCapLimit and scaledObjectRefs properties to CRD schema, add powerCapLimit and scaledObjectRefs in powercappingconfig.

### DIFF
--- a/deploy/climatik-operator/manifests/crd.yaml
+++ b/deploy/climatik-operator/manifests/crd.yaml
@@ -25,6 +25,22 @@ spec:
                   type: integer
                 temperatureThresholdCelsius:
                   type: integer
+                powerCapLimit:
+                  type: integer
+                scaledObjectRefs:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      metadata:
+                        type: object
+                        properties:
+                          name:
+                            type: string
   scope: Namespaced
   names:
     plural: gpupowercappingconfigs

--- a/deploy/climatik-operator/manifests/sample_powercapping.yaml
+++ b/deploy/climatik-operator/manifests/sample_powercapping.yaml
@@ -3,6 +3,10 @@ kind: PowerCappingConfig
 metadata:
   name: llm-example-powercappingconfig
 spec:
+  workloadType: training
+  efficiencyLevel: high
+  powerCapWatts: 1000
+  temperatureThresholdCelsius: 75
   powerCapLimit: 1000
   scaledObjectRefs:
     - apiVersion: keda.sh/v1alpha1


### PR DESCRIPTION
- In order to deploy the llm-example-powercappingconfig from deploy/climatik-operator/manifests successfully. I did the following change:
    - Added `powerCapLimit` property to the spec with type integer to set the power cap limit for the GPU.
    - Added `scaledObjectRefs` property to the spec with type array to reference and manage scaled objects related to power capping configurations. Each object in the array includes `apiVersion`, `kind`, and `metadata` with a `name` field.