### PR TITLE
chore: automate the process of replacing hard coded credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,7 @@ To install the power capping operator, follow these steps:
    git clone https://github.com/Climatik-Project/Climatik-Project
    ```
 
-2. Change hard coded Github Username in Climatik-Project/config/manager/manager.yaml, Climatik-Project/deploy/climatik-operator/manifests/deployment.yaml
-
-   ```bash
-   Replace <your-user-name> with your own username.
-   ```
-
-3. Set up Github PAT to use ghcr.io
+2. Set up Github PAT to use ghcr.io
 
    ```bash
    export GITHUB_PAT=<your-personal-access-token>
@@ -87,16 +81,7 @@ To install the power capping operator, follow these steps:
    export GITHUB_REPO=climatik-project
    ```
 
-4. Create secret with Github Username & Repo name for Kubernetes:
-
-   ```bash
-   kubectl delete secret github-secret
-   kubectl create secret generic github-secret \
-         --from-literal=GITHUB_USERNAME=$GITHUB_USERNAME \
-         --from-literal=GITHUB_REPO=$GITHUB_REPO
-   ```
-
-5. Python Libraries:
+3. Python Libraries:
 
    ```bash
    python -m venv venv
@@ -104,21 +89,21 @@ To install the power capping operator, follow these steps:
    pip install -r python/climatik_operator/requirements.txt
    ```
 
-6. Install the necessary CRDs and operators:
+4. Install the necessary CRDs and operators:
 
    ```bash
    make cluster-up
    make
    ```
 
-7. Verify pods exist:
+5. Verify pods exist:
 
    ```bash
    kubectl get pods --all-namespaces
    kubectl describe pod -n operator-powercapping-system operator-powercapping-controller-manager
    ```
 
-8. Configure the power capping CRD with the desired power cap limit, rack-level constraints, and other parameters. Refer
+6. Configure the power capping CRD with the desired power cap limit, rack-level constraints, and other parameters. Refer
    to the [CRD documentation](docs/crd.md) for more details.
 
 ## 5. Usage

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- manager.yaml
+  - manager.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: ghcr.io/zhifanl/climatik-project:latest # Use placeholder
+        image: ghcr.io/${GITHUB_USERNAME}/climatik-project:latest # Use placeholder
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: ghcr.io/<your-user-name>/climatik-project:latest # Use placeholders for the environment variables
+        image: ghcr.io/zhifanl/climatik-project:latest # Use placeholder
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/climatik-operator/manifests/deployment.yaml
+++ b/deploy/climatik-operator/manifests/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             cpu: 5m
             memory: 64Mi
       - name: manager
-        image: ghcr.io/<your-user-name>/climatik-project:latest
+        image: ghcr.io/${GITHUB_USERNAME}/${GITHUB_REPO}:latest
         command:
         - /manager
         args:
@@ -73,6 +73,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: power-capping-operator
+  namespace: operator-powercapping-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -97,4 +98,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: power-capping-operator
-  namespace: default
+  namespace: operator-powercapping-system


### PR DESCRIPTION
## What has been changed:

- Update Makefile to use sed for value replacement and set default target
- Added modify-manager-yaml target to use sed for replacing GITHUB_USERNAME and GITHUB_REPO in manager.yaml.
- Set default target to run tests, build-image-ghcr, push-image-ghcr, modify-manager-yaml, and deploy-ghcr.
- Ensured running `make` without arguments executes the default target.