### PR TITLE
fix: remove readiness probe and keep only liveness probe to avoid docker image failing to run on cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ deploy: release
 	echo "$$file" | kubectl apply -f -
 
 deploy-ghcr: release-ghcr
+	kubectl delete deployment operator-powercapping-controller-manager   -n operator-powercapping-system --ignore-not-found
 	kubectl apply -f config/crd/bases
 	kustomize build config/default | kubectl apply -f -
 	kubectl apply -f deploy/climatik-operator/manifests/crd.yaml

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ To install the power capping operator, follow these steps:
 
    ```bash
    kubectl get pods --all-namespaces
+   kubectl get deployments --all-namespaces
    kubectl describe pod -n operator-powercapping-system operator-powercapping-controller-manager
    ```
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -141,10 +141,10 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
+	// if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	// 	setupLog.Error(err, "unable to set up ready check")
+	// 	os.Exit(1)
+	// }
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,26 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
-      # affinity:
-      #   nodeAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       nodeSelectorTerms:
-      #         - matchExpressions:
-      #           - key: kubernetes.io/arch
-      #             operator: In
-      #             values:
-      #               - amd64
-      #               - arm64
-      #               - ppc64le
-      #               - s390x
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges
@@ -71,6 +71,7 @@ spec:
         args:
         - --leader-elect
         image: ghcr.io/${GITHUB_USERNAME}/climatik-project:latest # Use placeholder
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
@@ -81,16 +82,21 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 15
+          initialDelaySeconds: 20
+          timeoutSeconds: 1
           periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          successThreshold: 1
+          failureThreshold: 3
+        # readinessProbe:
+        #   httpGet:
+        #     path: /readyz
+        #     port: 8081
+        #   initialDelaySeconds: 20
+        #   timeoutSeconds: 1
+        #   periodSeconds: 20
+        #   successThreshold: 1
+        #   failureThreshold: 3
+        # Configure the resources accordingly based on the project requirements.
         resources:
           limits:
             cpu: 500m
@@ -98,5 +104,9 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: metrics
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/deploy/climatik-operator/manifests/deployment.yaml
+++ b/deploy/climatik-operator/manifests/deployment.yaml
@@ -53,14 +53,14 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 20
           failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-          periodSeconds: 10
-          failureThreshold: 3
+        # readinessProbe:
+        #   httpGet:
+        #     path: /readyz
+        #     port: 8081
+        #   initialDelaySeconds: 5
+        #   timeoutSeconds: 1
+        #   periodSeconds: 10
+        #   failureThreshold: 3
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
## What has been changed?

- fix: comment out readiness probe and keep only liveness probe to avoid docker image failing to run on cluster
- chore: in the makefile, delete existing operator-powercapping-controller-manager when deploying a new one
- chore: add documentation to check deployments