### PR TITLE
fix: fix compilation errors, organize different alerts into adapters folder, organize tests into tests folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ default: tests build-image-ghcr push-image-ghcr modify-manager-yaml clean-up dep
 
 tests:
 	PROMETHEUS_HOST="http://localhost:9090" python -m unittest discover python/tests
-	go test -v ./internal/alert
+	go test -v ./internal/alert/tests
 
 build-image: tests
 	docker build -t $(IMG):latest .

--- a/internal/alert/adapters/git_ops.go
+++ b/internal/alert/adapters/git_ops.go
@@ -1,4 +1,4 @@
-package alert
+package adapters
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ type GitOpsAlertManager struct {
 	alerts  map[string]string // In-memory storage for alerts
 }
 
-func NewGitOpsAlertManager(repoURL, repoDir string) (AlertManager, error) {
+func NewGitOpsAlertManager(repoURL, repoDir string) (*GitOpsAlertManager, error) {
 	// We're not using repoURL in this simplified version, but keeping it for interface consistency
 	return &GitOpsAlertManager{
 		repoDir: repoDir,

--- a/internal/alert/adapters/slack.go
+++ b/internal/alert/adapters/slack.go
@@ -1,4 +1,4 @@
-package alert
+package adapters
 
 import (
 	"bytes"

--- a/internal/alert/factory.go
+++ b/internal/alert/factory.go
@@ -3,6 +3,8 @@ package alert
 
 import (
 	"fmt"
+
+	adapters "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
 )
 
 type AlertManagerType string
@@ -16,11 +18,11 @@ const (
 func NewAlertManager(managerType AlertManagerType, config map[string]string) (AlertManager, error) {
 	switch managerType {
 	case Prometheus:
-		return NewPrometheusAlertManager(config["prometheusAddress"])
+		return adapters.NewPrometheusAlertManager(config["prometheusAddress"])
 	case GitOps:
-		return NewGitOpsAlertManager(config["repoURL"], config["repoDir"])
+		return adapters.NewGitOpsAlertManager(config["repoURL"], config["repoDir"])
 	case Slack:
-		return NewSlackAlertManager(config["webhookURL"])
+		return adapters.NewSlackAlertManager(config["webhookURL"])
 	default:
 		return nil, fmt.Errorf("unsupported alert manager type: %s", managerType)
 	}

--- a/internal/alert/service.go
+++ b/internal/alert/service.go
@@ -2,7 +2,7 @@
 package alert
 
 type AlertService struct {
-	pubsub *PubSub
+	Pubsub *PubSub
 }
 
 func NewAlertService(config map[string]map[string]string) (*AlertService, error) {
@@ -10,10 +10,10 @@ func NewAlertService(config map[string]map[string]string) (*AlertService, error)
 	if err != nil {
 		return nil, err
 	}
-	return &AlertService{pubsub: pubsub}, nil
+	return &AlertService{Pubsub: pubsub}, nil
 }
 
 func (s *AlertService) SendAlert(podName string, powerCapValue int, devices map[string]string) error {
-	s.pubsub.Publish("alerts", podName, powerCapValue, devices)
+	s.Pubsub.Publish("alerts", podName, powerCapValue, devices)
 	return nil
 }

--- a/internal/alert/tests/slack_notification_test.go
+++ b/internal/alert/tests/slack_notification_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
+
+	adapters "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
 )
 
 func TestSlackAlertActualNotification(t *testing.T) {
@@ -21,7 +23,7 @@ func TestSlackAlertActualNotification(t *testing.T) {
 	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
 	assert.NotEmpty(t, webhookURL, "SLACK_WEBHOOK_URL is not set")
 
-	manager, err := NewSlackAlertManager(webhookURL)
+	manager, err := adapters.NewSlackAlertManager(webhookURL)
 	assert.NoError(t, err)
 
 	devices := map[string]string{

--- a/internal/webhook/handlers/gitops_handler.go
+++ b/internal/webhook/handlers/gitops_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 
-	alert "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
+	adapters "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
 	"github.com/Climatik-Project/Climatik-Project/internal/webhook/runners"
 )
 
@@ -12,7 +12,7 @@ type GitOpsAlertHandler struct {
 }
 
 func (h *GitOpsAlertHandler) HandleAlert(payload []byte) error {
-	var request alert.GitOpsAlertManager
+	var request adapters.GitOpsAlertManager
 	if err := json.Unmarshal(payload, &request); err != nil {
 		return err
 	}

--- a/internal/webhook/handlers/prometheus_handler.go
+++ b/internal/webhook/handlers/prometheus_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 
-	"github.com/Climatik-Project/Climatik-Project/internal/alert"
+	adapters "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
 	"github.com/Climatik-Project/Climatik-Project/internal/webhook/runners"
 )
 
@@ -12,7 +12,7 @@ type PrometheusAlertHandler struct {
 }
 
 func (h *PrometheusAlertHandler) HandleAlert(payload []byte) error {
-	var request alert.PrometheusAlert
+	var request adapters.PrometheusAlert
 	if err := json.Unmarshal(payload, &request); err != nil {
 		return err
 	}

--- a/internal/webhook/handlers/slack_handler.go
+++ b/internal/webhook/handlers/slack_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 
-	"github.com/Climatik-Project/Climatik-Project/internal/alert"
+	adapters "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
 	"github.com/Climatik-Project/Climatik-Project/internal/webhook/runners"
 )
 
@@ -12,7 +12,7 @@ type SlackAlertHandler struct {
 }
 
 func (h *SlackAlertHandler) HandleAlert(payload []byte) error {
-	var request alert.SlackAlert
+	var request adapters.SlackAlert
 	if err := json.Unmarshal(payload, &request); err != nil {
 		return err
 	}

--- a/test/webhook/slack.go
+++ b/test/webhook/slack.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/Climatik-Project/Climatik-Project/internal/alert"
+	alert "github.com/Climatik-Project/Climatik-Project/internal/alert/adapters"
 	"github.com/joho/godotenv"
 )
 


### PR DESCRIPTION
## What has been changed?

fix: fix compilation errors 
chore: organize different alerts into adapters folder
chore: organize test files into tests folder
chore: change test alerts folder in makefile

## How is it tested?

It is tested by running go test -v ./internal/alert/tests