### PR TITLE
Fix: Add null check for config parameter in SlackAlertManager.CreateAlert

### DIFF
--- a/internal/alert/adapters/slack.go
+++ b/internal/alert/adapters/slack.go
@@ -40,6 +40,10 @@ func NewSlackAlertManager(webhookURL string) (*SlackAlertManager, error) {
 }
 
 func (s *SlackAlertManager) CreateAlert(podName string, powerCapValue int, devices map[string]string, config *powercappingv1alpha1.PowerCappingConfig) error {
+	if config == nil {
+		return fmt.Errorf("config parameter cannot be nil")
+	}
+
 	currentPower := float64(powerCapValue) // You might want to get the actual current power from somewhere
 
 	alert := SlackAlert{


### PR DESCRIPTION
## Summary

This PR fixes a null pointer dereference bug in `SlackAlertManager.CreateAlert` that could cause a panic when a nil config is passed.

## Changes

- Added a nil check for the `config` parameter at the beginning of `CreateAlert` method
- Returns a descriptive error if config is nil

## Before

```go
func (s *SlackAlertManager) CreateAlert(...) error {
    currentPower := float64(powerCapValue)
    // ... directly accesses config.Spec without checking if config is nil
    message += fmt.Sprintf("Workload Type: %s\n", config.Spec.WorkloadType)
    // ... more accesses to config.Spec...
}
```

## After

```go
func (s *SlackAlertManager) CreateAlert(...) error {
    if config == nil {
        return fmt.Errorf("config parameter cannot be nil")
    }
    currentPower := float64(powerCapValue)
    // ... safe to access config.Spec now
}
```

## Testing

The fix ensures that calling `CreateAlert` with a nil config returns an error instead of panicking.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.